### PR TITLE
Adds dependabot group for Rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configures dependabot to group all Rust dependencies
together for easier management and review of updates.
